### PR TITLE
Pat second attempt reveal page

### DIFF
--- a/frontend/src/components/question/Decision.js
+++ b/frontend/src/components/question/Decision.js
@@ -19,7 +19,7 @@ class Decision extends Component {
       decision: "",
       answersArray: [],
       decisionCreatorId: "",
-      publicReveal : false,
+      voteOver : false,
       userId :'',
       publicRevalButtonText: 'reveal',
     };
@@ -37,7 +37,7 @@ class Decision extends Component {
           answersArray: res.data[0].answers.map(x => x.answerText),
           decisionCreatorId: res.data[0].decisionCreatorId,
           userId : res.data[0].userId,
-          publicReveal : res.data[0].publicReveal,
+          voteOver : res.data[0].voteOver,
         });
         // console.log(
         //   "res.data[0].answers.map(x => x.answerText)",
@@ -75,7 +75,7 @@ class Decision extends Component {
       postIsActive: false,
       voteIsActive: false,
       revealIsActive: true,
-      publicReveal : true // now the general public can see the Reveal page but 
+      voteOver : true // now the general public can see the Reveal page but 
                           // Todo :i haven't saved this to the database, need help on this, pat will
                           // create a put decison route and update route url here . we have to trigger
                           // an axios request to set this decision public reveal to true
@@ -90,7 +90,7 @@ class Decision extends Component {
           postIsActive: false,
           voteIsActive: false,
           revealIsActive: true,
-          publicReveal : true,
+          voteOver : true,
           publicRevalButtonText : 'sneak peek'
         });
 
@@ -100,7 +100,7 @@ class Decision extends Component {
           postIsActive: false,
           voteIsActive: false,
           revealIsActive: true,
-          publicReveal : false,  
+          voteOver : false,  
           publicRevalButtonText : 'reveal',
         });
       }
@@ -111,7 +111,7 @@ class Decision extends Component {
         postIsActive: false,
         voteIsActive: false,
         revealIsActive: true,
-        publicReveal : true // now the general public can see the Reveal page but 
+        voteOver : true // now the general public can see the Reveal page but 
                             // Todo :i haven't saved this to the database, need help on this, pat will
                             // create a put decison route and update route url here . we have to trigger
                             // an axios request to set this decision public reveal to true
@@ -159,11 +159,11 @@ class Decision extends Component {
             {this.state.publicRevalButtonText}
           </button>
           <button
-            disabled={!((this.state.decisionCreatorId == this.state.userId) || this.state.publicReveal)} // check decision creator id is
+            disabled={!((this.state.decisionCreatorId == this.state.userId) || this.state.voteOver)} // check decision creator id is
                 // decision createor the same as the person logged in or it's already been publicly revealed and
                 // saved on the database as publiclyRevealed
                 // todo , when decision creator clicks on reveal for the first time , make them
-                // confirm via popup to allow the reveal and then set state on publicReveal
+                // confirm via popup to allow the reveal and then set state on voteOver
             className={
               this.state.revealIsActive ? "active-tab" : "inactive-tab"
             }

--- a/frontend/src/components/question/Decision.js
+++ b/frontend/src/components/question/Decision.js
@@ -18,7 +18,10 @@ class Decision extends Component {
       decisionCode: props.match.params.id,
       decision: "",
       answersArray: [],
-      decisionCreatorId: ""
+      decisionCreatorId: "",
+      publicReveal : false,
+      userId :'',
+      publicRevalButtonText: 'reveal',
     };
   }
 
@@ -32,7 +35,9 @@ class Decision extends Component {
         this.setState({
           decision: res.data[0].decisionText,
           answersArray: res.data[0].answers.map(x => x.answerText),
-          decisionCreatorId: res.data[0].decisionCreatorId
+          decisionCreatorId: res.data[0].decisionCreatorId,
+          userId : res.data[0].userId,
+          publicReveal : res.data[0].publicReveal,
         });
         // console.log(
         //   "res.data[0].answers.map(x => x.answerText)",
@@ -69,8 +74,49 @@ class Decision extends Component {
       renderPage: "reveal",
       postIsActive: false,
       voteIsActive: false,
-      revealIsActive: true
+      revealIsActive: true,
+      publicReveal : true // now the general public can see the Reveal page but 
+                          // Todo :i haven't saved this to the database, need help on this, pat will
+                          // create a put decison route and update route url here . we have to trigger
+                          // an axios request to set this decision public reveal to true
     });
+  };
+
+  onRevealButtonClick1 = () => {
+    if (this.state.decisionCreatorId == this.state.userId) {
+      if(this.publicRevalButtonText == 'reveal') {
+        this.setState({
+          renderPage: "reveal",
+          postIsActive: false,
+          voteIsActive: false,
+          revealIsActive: true,
+          publicReveal : true,
+          publicRevalButtonText : 'sneak peek'
+        });
+
+      } else if (this.state.publicRevalButtonText == 'sneak peek') {
+        this.setState({
+          renderPage: "reveal",
+          postIsActive: false,
+          voteIsActive: false,
+          revealIsActive: true,
+          publicReveal : false,  
+          publicRevalButtonText : 'reveal',
+        });
+      }
+
+    } else {  // it's a normal user show them reveal button 
+      this.setState({
+        renderPage: "reveal",
+        postIsActive: false,
+        voteIsActive: false,
+        revealIsActive: true,
+        publicReveal : true // now the general public can see the Reveal page but 
+                            // Todo :i haven't saved this to the database, need help on this, pat will
+                            // create a put decison route and update route url here . we have to trigger
+                            // an axios request to set this decision public reveal to true
+      });
+    }
   };
 
   render() {
@@ -96,11 +142,28 @@ class Decision extends Component {
           <button
             className={this.state.voteIsActive ? "active-tab" : "inactive-tab"}
             onClick={this.onVoteButtonClick}
+            // if there are no answers , there is nothing to vote on
+            disabled= {!this.state.answersArray}  //answersArray empty, null or lenght 0 is false
           >
             Vote
           </button>
           <button
-            disabled={!this.state.decisionCreatorId}
+            disabled={!(this.state.decisionCreatorId == this.state.userId)} // check decision creator id is
+                // decision createor the same as the person logged in or it's already been publicly revealed and
+                
+            className={
+              this.state.revealIsActive ? "active-tab" : "inactive-tab"
+            }
+            onClick={this.onRevealButtonClick1}
+          >
+            {this.state.publicRevalButtonText}
+          </button>
+          <button
+            disabled={!((this.state.decisionCreatorId == this.state.userId) || this.state.publicReveal)} // check decision creator id is
+                // decision createor the same as the person logged in or it's already been publicly revealed and
+                // saved on the database as publiclyRevealed
+                // todo , when decision creator clicks on reveal for the first time , make them
+                // confirm via popup to allow the reveal and then set state on publicReveal
             className={
               this.state.revealIsActive ? "active-tab" : "inactive-tab"
             }

--- a/server/db/DecisionModel.js
+++ b/server/db/DecisionModel.js
@@ -23,6 +23,10 @@ const DecisionSchema =  new mongoose.Schema({
         upVotes: [String],
         downVotes: [String]}
     ],
+    publicReveal: {
+        type: Boolean,
+        default : false,
+    },
 
     createdOn: {
         type: Date,

--- a/server/db/DecisionModel.js
+++ b/server/db/DecisionModel.js
@@ -23,7 +23,7 @@ const DecisionSchema =  new mongoose.Schema({
         upVotes: [String],
         downVotes: [String]}
     ],
-    publicReveal: {
+    voteOver: {
         type: Boolean,
         default : false,
     },

--- a/server/server.js
+++ b/server/server.js
@@ -173,11 +173,11 @@ server.get(
 );
 
 // postman test example localhost:8000/api/decision/decisionCode/k65gy
-server.get("/api/decision/decisionCode/:decisionCode", function(req, res) {
+server.get("/api/decision/decisionCode/:decisionCode",passport.authenticate("jwt", { session: false }), function(req, res) {
   const decisionCode = req.params.decisionCode;
   console.log("decisionCode", decisionCode);
   Decision.find({ decisionCode: decisionCode }).then(
-    decision => res.status(STATUS_OKAY).json(decision),
+    decision =>{decision.userId = req.user._id; res.status(STATUS_OKAY).json(decision)},
     err =>
       res
         .status(STATUS_NOT_FOUND)
@@ -370,7 +370,7 @@ server.get(
 );
 
 mongoose.Promise = global.Promise;
-const connect = mongoose.connect("mongodb://localhost/test");
+const connect = mongoose.connect("mongodb://localhost/test1");
 //  'mongodb://sneha.thadani:decisionjam@ds163769.mlab.com:63769/decisionjam');
 
 connect.then(


### PR DESCRIPTION
when the decision maker clicks the reveal button we need some way to store this info in the db 
so that we know users are allowed to view the decision results . Boolean publicReveal on decision models stores this, i'm not sending this to axios and i need help on that. 

you'll notice there is a second reveal button in this branch. I created an experimental (means ugly code 
and not fully working) button that in the RevealButtonClick1 handler checks if the decisoncreater is the logged in user, if so we toggle the reveal button text from reveal to sneak peek and visa versa. only the publicreveal boolean gets set to true only when in the reveal mode , not sneak preview, so that means the decison maker can sneakily look at how the voting is going without ending the voting. 

# Description

Please include a summary of the change and a link to which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [ x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x ] Test A  Everything has been tested on postman register, login and a route that needs jwt
- [ ] Test B

# Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
